### PR TITLE
Updated run.cmd to allow it to run the script GetTenantRegionScope.ps1

### DIFF
--- a/1-java-api-idtokenhint/run.cmd
+++ b/1-java-api-idtokenhint/run.cmd
@@ -11,7 +11,7 @@ set AADVC_PRESENTATIONFILE=%cd%\presentation_request_config.json
 set AADVC_ISSUANCEFILE=%cd%\issuance_request_config.json
 
 rem get the tenant region scope and if it is an EU tenant, modify the endpoint 
-for /f "delims=" %%a in ('powershell .\GetTenantRegionScope.ps1 -TenantId %AADVC_TenantId%') do Set "AADVC_TenantRegionScope=%%a"
+for /f "delims=" %%a in ('powershell -executionpolicy RemoteSigned -File .\GetTenantRegionScope.ps1 -TenantId %AADVC_TenantId%') do Set "AADVC_TenantRegionScope=%%a"
 if "%AADVC_TenantRegionScope%" == "EU" set hostNameRegion=eu.
 
 set AADVC_ApiEndpoint=https://beta.%hostNameRegion%did.msidentity.com/v1.0/{0}/verifiablecredentials/request


### PR DESCRIPTION
## Purpose
Without this change the run.cmd batch file cannot run the GetTenantRegionScope.ps1 script and thus it is causing errors during execution. The problem is that the default execution policy in Powershell does not allow to run the script.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->